### PR TITLE
feat(HttpObject): test fluent chaining

### DIFF
--- a/src/main/java/berlin/yuna/nano/helper/logger/logic/LogQueue.java
+++ b/src/main/java/berlin/yuna/nano/helper/logger/logic/LogQueue.java
@@ -80,7 +80,7 @@ public class LogQueue extends Service {
     }
 
     protected void process() {
-        while (isReady() || !queue.isEmpty()) {
+        while (isReady() || (queue != null && !queue.isEmpty())) {
             try {
                 final Pair<Logger, LogRecord> pair = queue.take();
                 if (pair.left() != this.logger.logger()) {

--- a/src/main/java/berlin/yuna/nano/services/http/HttpService.java
+++ b/src/main/java/berlin/yuna/nano/services/http/HttpService.java
@@ -42,8 +42,8 @@ public class HttpService extends Service {
     public synchronized void start(final Supplier<Context> contextSub) {
         isReady.set(false, true, state -> {
             final Context context = contextSub.get().newContext(HttpService.class, null);
-            final int port = context.getOpt(Integer.class, "app_service_http_port").filter(p -> p > 0).orElseGet(() -> nextFreePort(8080));
             handleHttps(context);
+            final int port = context.getOpt(Integer.class, "app_service_http_port").filter(p -> p > 0).orElseGet(() -> nextFreePort(8080));
             try {
                 server = HttpServer.create(new InetSocketAddress(port), 0);
                 server.setExecutor(context.nano().threadPool());
@@ -140,8 +140,8 @@ public class HttpService extends Service {
     }
 
     public static int nextFreePort(final int startPort) {
-        for (int i = 1; i < 1024; i++) {
-            final int port = i + startPort;
+        for (int i = 0; i < 1024; i++) {
+            final int port = i + (Math.max(startPort, 1));
             if (!isPortInUse(port)) {
                 return port;
             }

--- a/src/main/java/berlin/yuna/nano/services/http/HttpService.java
+++ b/src/main/java/berlin/yuna/nano/services/http/HttpService.java
@@ -6,6 +6,7 @@ import berlin.yuna.nano.core.model.Unhandled;
 import berlin.yuna.nano.services.http.model.ContentType;
 import berlin.yuna.nano.services.http.model.HttpHeaders;
 import berlin.yuna.nano.services.http.model.HttpObject;
+import berlin.yuna.typemap.logic.TypeConverter;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpServer;
 
@@ -16,7 +17,6 @@ import java.net.Socket;
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 
@@ -116,12 +116,20 @@ public class HttpService extends Service {
         try {
             final byte[] body = response.body() != null ? response.body() : new byte[0];
             final int statusCode = response.statusCode() > -1 && response.statusCode() < 600 ? response.statusCode() : 200;
-            final Map<String, String> headers = response.headers() == null ? new HashMap<>() : new HashMap<>(response.headers());
-            headers.computeIfAbsent(HttpHeaders.CONTENT_TYPE, value -> {
+            response.headers().computeIfAbsent(HttpHeaders.CONTENT_TYPE, value -> {
                 final String str = new String(body, Charset.defaultCharset());
                 return (str.startsWith("{") && str.endsWith("}")) || (str.startsWith("[") && str.endsWith("]")) ? ContentType.APPLICATION_JSON.value() : ContentType.TEXT_PLAIN.value();
             });
-            headers.forEach((key, value) -> exchange.getResponseHeaders().put(key, List.of(value)));
+            // Fixme: TypeMap needs working method `getMap(String.class, String.class)` to convert headers to Map<String, String>
+            response.headers().keySet().forEach(rawKey -> {
+                final String key = TypeConverter.convertObj(rawKey, String.class);
+                if (key != null) {
+                    final List<String> value = response.headers().getList(String.class, rawKey);
+                    if (value != null) {
+                        exchange.getResponseHeaders().put(key, value);
+                    }
+                }
+            });
             exchange.sendResponseHeaders(statusCode, body.length);
             try (final OutputStream os = exchange.getResponseBody()) {
                 os.write(body);

--- a/src/main/java/berlin/yuna/nano/services/http/model/ContentType.java
+++ b/src/main/java/berlin/yuna/nano/services/http/model/ContentType.java
@@ -40,7 +40,7 @@ public enum ContentType {
 
     public static ContentType fromValue(final String value) {
         for (final ContentType type : values()) {
-            if (type.value().equals(value) || type.name().equals(value)) {
+            if (type.value().equalsIgnoreCase(value) || type.name().equalsIgnoreCase(value)) {
                 return type;
             }
         }

--- a/src/main/java/berlin/yuna/nano/services/http/model/HttpObject.java
+++ b/src/main/java/berlin/yuna/nano/services/http/model/HttpObject.java
@@ -43,10 +43,6 @@ public class HttpObject {
         this.exchange = null;
     }
 
-    public static boolean isMethod(final HttpObject request, final HttpMethod method) {
-        return request.method.name().equals(method.name());
-    }
-
     public boolean isMethodGet() {
         return HttpMethod.GET.equals(method);
     }
@@ -556,6 +552,12 @@ public class HttpObject {
             .add("body=" + Arrays.toString(body))
             .add("headers=" + headers)
             .toString();
+    }
+
+    // ########## STATICS ##########
+
+    public static boolean isMethod(final HttpObject request, final HttpMethod method) {
+        return request.method.name().equals(method.name());
     }
 
     public static TypeMap convertHeaders(final Map<String, ?> headers) {

--- a/src/main/java/berlin/yuna/nano/services/http/model/HttpObject.java
+++ b/src/main/java/berlin/yuna/nano/services/http/model/HttpObject.java
@@ -24,12 +24,12 @@ public class HttpObject {
 
     protected HttpMethod method;
     protected String path;
-    protected final HttpExchange exchange;
     protected byte[] body;
     protected TypeMap headers;
     protected TypeMap queryParams;
     protected TypeMap pathParams;
     private int statusCode;
+    protected final HttpExchange exchange;
 
     public HttpObject(final HttpExchange exchange) {
         this.exchange = exchange;
@@ -106,12 +106,7 @@ public class HttpObject {
     }
 
     public HttpObject contentType(final Charset charset, final String... contentType) {
-        headers().put(CONTENT_TYPE, Arrays.stream(contentType)
-            .map(ContentType::fromValue)
-            .filter(Objects::nonNull)
-            .map(ContentType::value)
-            .collect(Collectors.joining(", ")) + (charset == null ? "" : "; charset=" + charset.name()));
-        return this;
+        return contentType(charset, Arrays.stream(contentType).map(ContentType::fromValue).filter(Objects::nonNull).toArray(ContentType[]::new));
     }
 
     public HttpObject contentType(final Charset charset, final ContentType... contentType) {

--- a/src/main/java/berlin/yuna/nano/services/http/model/HttpObject.java
+++ b/src/main/java/berlin/yuna/nano/services/http/model/HttpObject.java
@@ -171,12 +171,19 @@ public class HttpObject {
     }
 
     public HttpObject accept(final String... contentType) {
-        headers().put(HttpHeaders.ACCEPT, Arrays.stream(contentType).map(ContentType::fromValue).filter(Objects::nonNull).map(ContentType::value).collect(Collectors.joining(", ")));
+        headers().put(HttpHeaders.ACCEPT, Arrays.stream(contentType)
+            .map(ContentType::fromValue)
+            .filter(Objects::nonNull)
+            .map(ContentType::value)
+            .collect(Collectors.joining(", ")));
         return this;
     }
 
     public HttpObject accept(final ContentType... contentType) {
-        headers().put(HttpHeaders.ACCEPT, Arrays.stream(contentType).filter(Objects::nonNull).map(ContentType::value).collect(Collectors.joining(", ")));
+        headers().put(HttpHeaders.ACCEPT, Arrays.stream(contentType)
+            .filter(Objects::nonNull)
+            .map(ContentType::value)
+            .collect(Collectors.joining(", ")));
         return this;
     }
 
@@ -190,10 +197,6 @@ public class HttpObject {
         return Arrays.stream(contentTypes).allMatch(result::contains);
     }
 
-    public boolean hasAccept(final ContentType contentType) {
-        return accepts().contains(contentType);
-    }
-
     public String acceptEncoding() {
         final List<String> result = acceptEncodings();
         return result.isEmpty() ? null : result.getFirst();
@@ -203,9 +206,9 @@ public class HttpObject {
         return splitHeaderValue(headers().getList(String.class, HttpHeaders.ACCEPT_ENCODING), v -> v);
     }
 
-    public boolean hasAcceptEncoding(final String... contentTypes) {
+    public boolean hasAcceptEncoding(final String... encodings) {
         final List<String> result = splitHeaderValue(headers().getList(String.class, HttpHeaders.ACCEPT_ENCODING), v -> v);
-        return Arrays.stream(contentTypes).allMatch(result::contains);
+        return Arrays.stream(encodings).allMatch(result::contains);
     }
 
     public Locale acceptLanguage() {
@@ -341,7 +344,7 @@ public class HttpObject {
      * @return {@code true} if the parameter exists, {@code false} otherwise.
      */
     public boolean containsQueryParam(final String key) {
-        return queryParams.containsKey(key);
+        return queryParams().containsKey(key);
     }
 
     /**
@@ -351,8 +354,7 @@ public class HttpObject {
      * @return the value of the parameter as a String, or {@code null} if the parameter does not exist.
      */
     public String queryParam(final String key) {
-        final Object value = queryParams.get(key);
-        return value != null ? value.toString() : null;
+        return queryParams().get(String.class, key);
     }
 
     /**
@@ -373,10 +375,7 @@ public class HttpObject {
 
         if (partsToMatch.length != parts.length) return false;
 
-        if (pathParams == null)
-            pathParams = new TypeMap();
-        else
-            pathParams.clear();
+        pathParams().clear();
         for (int i = 0; i < partsToMatch.length; i++) {
             if (!partsToMatch[i].equals(parts[i])) {
                 if (partsToMatch[i].startsWith("{")) {
@@ -398,6 +397,8 @@ public class HttpObject {
      * @return a {@link TypeMap} of path parameters.
      */
     public TypeMap pathParams() {
+        if (pathParams == null)
+            pathParams = new TypeMap();
         return pathParams;
     }
 
@@ -408,27 +409,27 @@ public class HttpObject {
      * @return the value of the path parameter, or {@code null} if it does not exist.
      */
     public String pathParam(final String key) {
-        return pathParams.get(String.class, key);
+        return pathParams().get(String.class, key);
     }
 
     /**
      * Retrieves the value of a specified header.
      *
-     * @param name the name of the header to retrieve.
-     * @return the value of the header, or {@code null} if the header is not found or {@code name} is {@code null}.
+     * @param key the key of the header to retrieve.
+     * @return the value of the header, or {@code null} if the header is not found or {@code key} is {@code null}.
      */
-    public String header(final String name) {
-        return name == null || headers == null ? null : headers.get(String.class, name.toLowerCase());
+    public String header(final String key) {
+        return key == null || headers == null ? null : headers.get(String.class, key.toLowerCase());
     }
 
     /**
      * Checks if a specified header exists in the {@link HttpObject}.
      *
-     * @param name the name of the header to check.
+     * @param key the key of the header to check.
      * @return {@code true} if the header exists, {@code false} otherwise.
      */
-    public boolean containsHeader(final String name) {
-        return name != null && headers != null && headers.containsKey(name.toLowerCase());
+    public boolean containsHeader(final String key) {
+        return key != null && headers != null && headers.containsKey(key.toLowerCase());
     }
 
     /**

--- a/src/main/java/berlin/yuna/nano/services/http/model/HttpObject.java
+++ b/src/main/java/berlin/yuna/nano/services/http/model/HttpObject.java
@@ -37,9 +37,6 @@ public class HttpObject {
     }
 
     public HttpObject() {
-        this.method = null;
-        this.path = null;
-        this.headers = new TypeMap();
         this.exchange = null;
     }
 
@@ -161,11 +158,11 @@ public class HttpObject {
     }
 
     public List<String> acceptEncodings() {
-        return splitHeaderValue(headers.getList(String.class, HttpHeaders.ACCEPT_ENCODING), v -> v);
+        return splitHeaderValue(headers().getList(String.class, HttpHeaders.ACCEPT_ENCODING), v -> v);
     }
 
     public boolean hasAcceptEncoding(final String... contentTypes) {
-        final List<String> result = splitHeaderValue(headers.getList(String.class, HttpHeaders.ACCEPT_ENCODING), v -> v);
+        final List<String> result = splitHeaderValue(headers().getList(String.class, HttpHeaders.ACCEPT_ENCODING), v -> v);
         return Arrays.stream(contentTypes).allMatch(result::contains);
     }
 
@@ -175,7 +172,7 @@ public class HttpObject {
     }
 
     public List<Locale> acceptLanguages() {
-        return splitHeaderValue(headers.getList(String.class, HttpHeaders.ACCEPT_LANGUAGE), Locale::forLanguageTag);
+        return splitHeaderValue(headers().getList(String.class, HttpHeaders.ACCEPT_LANGUAGE), Locale::forLanguageTag);
     }
 
     public boolean hasContentTypeJson() {
@@ -453,13 +450,6 @@ public class HttpObject {
         return exchange;
     }
 
-//    private HttpResponse generateHttpResponse(final int statusCode, final byte[] body, final Map<String, String> headers) {
-//        return new HttpResponse(statusCode, body, headers);
-//    }
-//    public HttpResponse generateHttpResponse(final int statusCode, final String body, final Map<String, String> headers) {
-//        return generateHttpResponse(statusCode, body.getBytes(), headers);
-//    }
-
     protected List<ContentType> contentSplitType(final String key) {
         return splitHeaderValue(headers().getList(String.class, key), ContentType::fromValue);
     }
@@ -532,25 +522,25 @@ public class HttpObject {
     }
 
     @Override
-    public boolean equals(final Object object) {
-        if (this == object) return true;
-        if (object == null || getClass() != object.getClass()) return false;
-        return statusCode == this.statusCode && Arrays.equals(body, this.body) && Objects.equals(headers, this.headers);
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (!(o instanceof final HttpObject that)) return false;
+        return statusCode == that.statusCode && method == that.method && Objects.equals(path, that.path) && Objects.deepEquals(body, that.body) && Objects.equals(headers, that.headers);
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(statusCode, headers);
-        result = 31 * result + Arrays.hashCode(body);
-        return result;
+        return Objects.hash(method, path, Arrays.hashCode(body), headers, statusCode);
     }
 
     @Override
     public String toString() {
         return new StringJoiner(", ", HttpObject.class.getSimpleName() + "[", "]")
             .add("statusCode=" + statusCode)
-            .add("body=" + Arrays.toString(body))
+            .add("path=" + path)
+            .add("method=" + method)
             .add("headers=" + headers)
+            .add("body=" + bodyAsString())
             .toString();
     }
 

--- a/src/main/java/berlin/yuna/nano/services/http/model/HttpObject.java
+++ b/src/main/java/berlin/yuna/nano/services/http/model/HttpObject.java
@@ -296,8 +296,8 @@ public class HttpObject {
     }
 
     public HttpObject path(final String path) {
-        final String[] parts = split(path, "?");
-        this.path = removeLast(parts[0], "/");
+        final String[] parts = path == null ? new String[0] : split(path, "?");
+        this.path = parts.length > 0 ? removeLast(parts[0], "/") : null;
         if (parts.length > 1) {
             queryParams = queryParamsOf(parts[1]);
         }
@@ -305,7 +305,7 @@ public class HttpObject {
     }
 
     public String bodyAsString() {
-        return body() == null ? null : new String(body(), Charset.defaultCharset());
+        return new String(body(), Charset.defaultCharset());
     }
 
     public TypeContainer<?> bodyAsJson() {

--- a/src/test/java/berlin/yuna/nano/model/HttpRequestTest.java
+++ b/src/test/java/berlin/yuna/nano/model/HttpRequestTest.java
@@ -17,7 +17,6 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -31,7 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class HttpRequestTest {
 
     @Test
-    void browserRequest() {
+    void browserRequestTest() {
         final HttpObject httpObject = new HttpObject()
             .method(HttpMethod.GET)
             .path("/notifications/indicator")
@@ -399,6 +398,15 @@ class HttpRequestTest {
     void testHeaderUserAgent() {
         assertThat(new HttpObject().header(USER_AGENT, "PostmanRuntime/7.36.3").header(USER_AGENT)).isEqualTo("PostmanRuntime/7.36.3");
         assertThat(new HttpObject().header(USER_AGENT, "PostmanRuntime/7.36.3").userAgent()).isEqualTo("PostmanRuntime/7.36.3");
+
+        final String macOsBrowser = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Safari/605.1.15";
+        final String chromeMobile = "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Mobile Safari/537.36";
+        assertThat(new HttpObject().userAgent(macOsBrowser).isFrontendCall()).isTrue();
+        assertThat(new HttpObject().userAgent(macOsBrowser).isMobileCall()).isFalse();
+        assertThat(new HttpObject().userAgent(chromeMobile).isFrontendCall()).isTrue();
+        assertThat(new HttpObject().userAgent(chromeMobile).isMobileCall()).isTrue();
+        assertThat(new HttpObject().isFrontendCall()).isFalse();
+        assertThat(new HttpObject().isMobileCall()).isFalse();
     }
 
     @Test

--- a/src/test/java/berlin/yuna/nano/model/HttpRequestTest.java
+++ b/src/test/java/berlin/yuna/nano/model/HttpRequestTest.java
@@ -30,6 +30,33 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class HttpRequestTest {
 
     @Test
+    void browserRequest() {
+        final HttpObject httpObject = new HttpObject()
+            .method(HttpMethod.GET)
+            .path("/notifications/indicator")
+            .header("Accept", "application/json")
+            .header("Accept-Encoding", "gzip, deflate, br")
+            .header("Accept-Language", "en-GB,en;q=0.9")
+            .header("Connection", "keep-alive")
+            .header("Host", "example.com")
+            .header("Referer", "https://example.com/test")
+            .header("Sec-Fetch-Dest", "empty")
+            .header("Sec-Fetch-Mode", "cors")
+            .header("Sec-Fetch-Site", "same-origin")
+            .header("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Safari/605.1.15")
+            .header("X-Requested-With", "XMLHttpRequest");
+        assertThat(httpObject.method()).isEqualTo(HttpMethod.GET);
+        assertThat(httpObject.path()).isEqualTo("/notifications/indicator");
+        assertThat(httpObject.accepts()).containsExactly(APPLICATION_JSON);
+        assertThat(httpObject.acceptEncodings()).containsExactly("gzip", "deflate", "br");
+        assertThat(httpObject.acceptLanguages()).containsExactly(Locale.UK, Locale.ENGLISH);
+        assertThat(httpObject.header(HOST)).isEqualTo("example.com");
+        assertThat(httpObject.header(REFERER)).isEqualTo("https://example.com/test");
+        assertThat(httpObject.userAgent()).isEqualTo("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4.1 Safari/605.1.15");
+        assertThat(httpObject.header("X-Requested-With")).isEqualTo("XMLHttpRequest");
+    }
+
+    @Test
     void testConstructor_withHttpExchange() {
         final Headers headers = new Headers();
         headers.add(CONTENT_TYPE, APPLICATION_JSON.value());
@@ -401,7 +428,7 @@ class HttpRequestTest {
         httpObject2.statusCode(200)
             .body("Sample body".getBytes());
 
-        assertThat(httpObject1.hashCode()).isEqualTo(httpObject2.hashCode());
+        assertThat(httpObject1.hashCode()).hasSameHashCodeAs(httpObject2.hashCode());
         assertThat(httpObject1.equals(httpObject2)).isTrue();
         assertThat(httpObject1.equals(new HttpObject())).isFalse();
         assertThat(httpObject1.equals("invalid")).isFalse();

--- a/src/test/java/berlin/yuna/nano/model/HttpRequestTest.java
+++ b/src/test/java/berlin/yuna/nano/model/HttpRequestTest.java
@@ -318,10 +318,14 @@ class HttpRequestTest {
             assertThat(httpObject.containsHeader(null)).isFalse();
             assertThat(httpObject.header("myNumber")).isEqualTo("123");
             assertThat(httpObject.header("mynumber")).isEqualTo("123");
+            assertThat(httpObject.header("invalid")).isNull();
+            assertThat(httpObject.header(null)).isNull();
             assertThat(httpObject.headers().get(Integer.class, "mynumber")).isEqualTo(123);
             assertThat(httpObject.contentTypes()).containsExactly(APPLICATION_JSON, TEXT_PLAIN);
             assertThat(httpObject.accepts()).containsExactly(APPLICATION_PDF, APPLICATION_JSON);
         }
+
+        assertThat(new HttpObject().headers()).isEmpty();
     }
 
     @Test
@@ -336,6 +340,8 @@ class HttpRequestTest {
         assertThat(httpObject2.host()).isEqualTo("example.com");
         assertThat(httpObject2.address()).isNotNull();
         assertThat(httpObject2.port()).isEqualTo(1337);
+
+        assertThat(new HttpObject().header(HttpHeaders.HOST, "no-port.com").port()).isEqualTo(-1);
     }
 
     @Test
@@ -358,6 +364,7 @@ class HttpRequestTest {
     void testAuthToken() {
         assertThat(new HttpObject().header(AUTHORIZATION, "Bearer 123").authToken()).containsExactly("123");
         assertThat(new HttpObject().header(AUTHORIZATION, "Basic QWxhZGRpbjpPcGVuU2VzYW1l").authToken()).containsExactly("Aladdin", "OpenSesame");
+        assertThat(new HttpObject().header(AUTHORIZATION, "123ABC").authToken()).containsExactly("123ABC");
     }
 
     @Test
@@ -385,38 +392,6 @@ class HttpRequestTest {
     }
 
     @Test
-    void testHttpObjectMethods() {
-        // Create a sample HTTP response
-//        final HttpObject httpObject = new HttpObject();
-//        httpObject.statusCode(200)
-//            .body("Sample body".getBytes())
-//            .headers(createSampleHeaders());
-//
-//        assertEquals(200, httpObject.statusCode());
-//        assertArrayEquals("Sample body".getBytes(), httpObject.body());
-//
-////        assertEquals(createSampleHeaders(), httpObject.headers());
-//
-//        httpObject.statusCode(404);
-//        assertEquals(404, httpObject.statusCode());
-//
-//        final HttpObject httpObjectCopy = new HttpObject();
-//        httpObjectCopy.statusCode(404)
-//            .body("Sample body".getBytes())
-//            .headers(createSampleHeaders());
-//        assertEquals(httpObjectCopy, httpObject);
-
-//        assertEquals(httpObjectCopy.hashCode(), httpObject.hashCode());
-//        final String expectedToString = "HttpObject[statusCode=404, body=[83, 97, 109, 112, 108, 101, 32, 98, 111, 100, 121], headers={Header1=Value1, Header2=Value2, NewHeader=Value}]";
-//        assertEquals(expectedToString, httpObject.toString());
-    }
-
-    // Utility method to create sample headers
-    private Map<String, String> createSampleHeaders() {
-        return Map.of("Content-Type", "application/json");
-    }
-
-    @Test
     void testHashCode() {
         final HttpObject httpObject1 = new HttpObject();
         httpObject1.statusCode(200)
@@ -426,17 +401,22 @@ class HttpRequestTest {
         httpObject2.statusCode(200)
             .body("Sample body".getBytes());
 
-        assertEquals(httpObject1.hashCode(), httpObject2.hashCode());
+        assertThat(httpObject1.hashCode()).isEqualTo(httpObject2.hashCode());
+        assertThat(httpObject1.equals(httpObject2)).isTrue();
+        assertThat(httpObject1.equals(new HttpObject())).isFalse();
+        assertThat(httpObject1.equals("invalid")).isFalse();
     }
 
     @Test
     void testToString() {
         final HttpObject httpObject = new HttpObject();
-        httpObject.statusCode(200)
-            .body("Sample body".getBytes());
+        httpObject
+            .statusCode(200)
+            .method(HttpMethod.GET)
+            .path("/test")
+            .body("Sample body");
 
-        final String expectedToString = "HttpObject[statusCode=200, body=[83, 97, 109, 112, 108, 101, 32, 98, 111, 100, 121], headers={}]";
-        assertEquals(expectedToString, httpObject.toString());
+        assertThat(httpObject).hasToString("HttpObject[statusCode=200, path=/test, method=GET, headers=null, body=Sample body]");
     }
 
 

--- a/src/test/java/berlin/yuna/nano/model/HttpRequestTest.java
+++ b/src/test/java/berlin/yuna/nano/model/HttpRequestTest.java
@@ -1,63 +1,59 @@
 package berlin.yuna.nano.model;
 
-import berlin.yuna.nano.services.http.model.ContentType;
 import berlin.yuna.nano.services.http.model.HttpHeaders;
 import berlin.yuna.nano.services.http.model.HttpMethod;
 import berlin.yuna.nano.services.http.model.HttpObject;
-import berlin.yuna.typemap.logic.XmlDecoder;
-import berlin.yuna.typemap.model.TypeContainer;
+import berlin.yuna.typemap.model.TypeList;
 import berlin.yuna.typemap.model.TypeMap;
 import com.sun.net.httpserver.Headers;
 import com.sun.net.httpserver.HttpContext;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpPrincipal;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
+import static berlin.yuna.nano.services.http.model.ContentType.*;
+import static berlin.yuna.nano.services.http.model.HttpHeaders.*;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class HttpRequestTest {
 
-    private HttpObject httpObject;
-    private final int PORT = 80;
-    private final String HOST = "localhost";
-    private final String PROTOCOL = "HTTP/1.1";
-    private final String AGENT = "PostmanRuntime/7.36.3";
-    private final String TOKEN = "Bearer 123";
-
-    @BeforeEach
-    void setUp() {
+    @Test
+    void testConstructor_withHttpExchange() {
         final Headers headers = new Headers();
-        headers.add(HttpHeaders.CONTENT_TYPE, "application/json");
-        headers.add(HttpHeaders.ACCEPT, "application/json");
-        headers.add(HttpHeaders.ACCEPT, "text/html");
-        headers.add(HttpHeaders.ACCEPT_ENCODING, "gzip");
-        headers.add(HttpHeaders.ACCEPT_ENCODING, "deflate");
-        headers.add(HttpHeaders.ACCEPT_LANGUAGE, "en-US");
-        headers.add(HttpHeaders.HOST, "example.com:1337");
-        final String testBody = "{\"key\": \"value\"}";
-        final HttpExchange exchange = createMockHttpExchange("GET", "/test", headers, testBody);
-        httpObject = new HttpObject(exchange);
+        headers.add(CONTENT_TYPE, APPLICATION_JSON.value());
+        final HttpObject httpObject = new HttpObject(createMockHttpExchange("GET", "/test", headers, "{\"key\": \"value\"}"));
+
+        assertThat(httpObject.method()).isEqualTo(HttpMethod.GET);
+        assertThat(httpObject.path()).isEqualTo("/test");
+        assertThat(httpObject.headers()).containsEntry(CONTENT_TYPE, Collections.singletonList(APPLICATION_JSON.value()));
+        assertThat(httpObject.exchange()).isNotNull();
     }
 
     @Test
-    void testConstructor() {
-        assertThat(httpObject.method()).isEqualTo(HttpMethod.GET.toString());
+    void testBuilder() {
+        final HttpObject httpObject = new HttpObject()
+            .method(HttpMethod.GET)
+            .path("/test")
+            .statusCode(-99)
+            .contentType(APPLICATION_JSON);
+
+        assertThat(httpObject.method()).isEqualTo(HttpMethod.GET);
         assertThat(httpObject.path()).isEqualTo("/test");
-        assertThat(httpObject.getHeaders()).containsEntry("content-type", Collections.singletonList("application/json"));
-        assertThat(httpObject.exchange()).isNotNull();
+        assertThat(httpObject.headers()).containsEntry(CONTENT_TYPE, APPLICATION_JSON.value());
+        assertThat(httpObject.statusCode()).isEqualTo(-99);
+        assertThat(httpObject.exchange()).isNull();
     }
 
     @Test
@@ -73,12 +69,17 @@ class HttpRequestTest {
 
     @Test
     void testIsMethod() {
-        assertThat(HttpObject.isMethod(httpObject, HttpMethod.GET)).isTrue();
-        assertThat(HttpObject.isMethod(httpObject, HttpMethod.POST)).isFalse();
+        for (final HttpMethod testMethod : HttpMethod.values()) {
+            final HttpObject httpObject = new HttpObject().method(testMethod);
+            for (final HttpMethod otherMethod : HttpMethod.values()) {
+                assertThat(HttpObject.isMethod(httpObject, otherMethod)).isEqualTo(otherMethod == testMethod);
+            }
+        }
     }
 
     @Test
     void testIsMethodGet() {
+        final HttpObject httpObject = new HttpObject().method(HttpMethod.GET);
         assertThat(httpObject.isMethodGet()).isTrue();
         assertThat(httpObject.isMethodPost()).isFalse();
         assertThat(httpObject.isMethodPut()).isFalse();
@@ -90,7 +91,39 @@ class HttpRequestTest {
     }
 
     @Test
-    void testContentTypeMethods() {
+    void testSetMethod() {
+        assertThat(new HttpObject().method(HttpMethod.GET).method()).isEqualTo(HttpMethod.GET);
+        assertThat(new HttpObject().method("PUT").method()).isEqualTo(HttpMethod.PUT);
+        assertThat(new HttpObject().method("pAtCh").method()).isEqualTo(HttpMethod.PATCH);
+        assertThat(new HttpObject().method("unknown").method()).isNull();
+    }
+
+    @Test
+    void testHeaderContentType() {
+        //TODO: test use case "Content-Type: application/json; charset=utf-8"
+
+        // ENUM
+        assertThat(new HttpObject().contentType(APPLICATION_JSON).contentType()).isEqualTo(APPLICATION_JSON);
+        assertThat(new HttpObject().contentType(APPLICATION_JSON).contentTypes()).containsExactly(APPLICATION_JSON);
+        assertThat(new HttpObject().contentType(APPLICATION_JSON, TEXT_PLAIN).contentTypes()).containsExactly(APPLICATION_JSON, TEXT_PLAIN);
+        assertThat(new HttpObject().contentType(APPLICATION_JSON, TEXT_PLAIN).header(CONTENT_TYPE)).isEqualTo(APPLICATION_JSON.value() + ", " + TEXT_PLAIN.value());
+        assertThat(new HttpObject().contentType(APPLICATION_JSON, TEXT_PLAIN).hasContentType(APPLICATION_JSON)).isTrue();
+        assertThat(new HttpObject().contentType(APPLICATION_JSON, TEXT_PLAIN).hasContentType(APPLICATION_JSON, TEXT_PLAIN)).isTrue();
+        assertThat(new HttpObject().contentType(APPLICATION_JSON, TEXT_PLAIN).hasContentType(APPLICATION_JSON, TEXT_PLAIN, APPLICATION_PDF)).isFalse();
+
+        // STRING
+        assertThat(new HttpObject().contentType("application/json").contentType()).isEqualTo(APPLICATION_JSON);
+        assertThat(new HttpObject().contentType("application/json").contentTypes()).containsExactly(APPLICATION_JSON);
+        assertThat(new HttpObject().contentType("application/json", "text/plain").contentTypes()).containsExactly(APPLICATION_JSON, TEXT_PLAIN);
+        assertThat(new HttpObject().contentType("application/json", "TexT/Plain").header(CONTENT_TYPE)).isEqualTo(APPLICATION_JSON.value() + ", " + TEXT_PLAIN.value());
+        assertThat(new HttpObject().contentType("application/json", "TexT/Plain").hasContentType(APPLICATION_JSON.value())).isTrue();
+        assertThat(new HttpObject().contentType("application/json", "TexT/Plain").hasContentType(APPLICATION_JSON.value(), TEXT_PLAIN.value())).isTrue();
+        assertThat(new HttpObject().contentType("application/json", "TexT/Plain").hasContentType(APPLICATION_JSON.value(), TEXT_PLAIN.value(), APPLICATION_PDF.value())).isFalse();
+    }
+
+    @Test
+    void testHasContentTypeMethods() {
+        final HttpObject httpObject = new HttpObject().contentType(APPLICATION_JSON);
         assertThat(httpObject.hasContentType("application/json")).isTrue();
         assertThat(httpObject.hasContentTypeJson()).isTrue();
         assertThat(httpObject.hasAcceptJson()).isTrue();
@@ -123,247 +156,233 @@ class HttpRequestTest {
     }
 
     @Test
-    void testBodyMethods() {
-        final String testBody = "{\"key\": \"value\"}";
-        final InputStream bodyStream = new ByteArrayInputStream(testBody.getBytes(Charset.defaultCharset()));
-        final InputStream oldStream = httpObject.exchange().getRequestBody();
-        httpObject.exchange().setStreams(bodyStream, null);
+    void testHeaderAccept() {
+        // ENUM
+        assertThat(new HttpObject().accept(APPLICATION_JSON).accept()).isEqualTo(APPLICATION_JSON);
+        assertThat(new HttpObject().accept(APPLICATION_JSON).accepts()).containsExactly(APPLICATION_JSON);
+        assertThat(new HttpObject().accept(APPLICATION_JSON, TEXT_PLAIN).accepts()).containsExactly(APPLICATION_JSON, TEXT_PLAIN);
+        assertThat(new HttpObject().accept(APPLICATION_JSON, TEXT_PLAIN).header(ACCEPT)).isEqualTo(APPLICATION_JSON.value() + ", " + TEXT_PLAIN.value());
+        assertThat(new HttpObject().accept(APPLICATION_JSON, TEXT_PLAIN).hasAccept(APPLICATION_JSON)).isTrue();
+        assertThat(new HttpObject().accept(APPLICATION_JSON, TEXT_PLAIN).hasAccept(APPLICATION_JSON, TEXT_PLAIN)).isTrue();
+        assertThat(new HttpObject().accept(APPLICATION_JSON, TEXT_PLAIN).hasAccept(APPLICATION_JSON, TEXT_PLAIN, APPLICATION_PDF)).isFalse();
 
-        assertThat(httpObject.bodyAsString()).isEqualTo(testBody);
-        assertThat(httpObject.bodyAsJson().get(String.class, "key")).isEqualTo("value");
-//
-//        HttpExchange exchange = createMockHttpExchange("GET", "/test?key1=value1&key2=value2", new Headers(), "\uD800");
-//        HttpRequest request = new HttpRequest(exchange);
-//        assertThat(request.bodyAsString()).isEqualTo(testBody);
-
-        httpObject.exchange().setStreams(oldStream, null);
+        // STRING
+        assertThat(new HttpObject().accept("application/json").accept()).isEqualTo(APPLICATION_JSON);
+        assertThat(new HttpObject().accept("application/json").accepts()).containsExactly(APPLICATION_JSON);
+        assertThat(new HttpObject().accept("application/json", "text/plain").accepts()).containsExactly(APPLICATION_JSON, TEXT_PLAIN);
+        assertThat(new HttpObject().accept("application/json", "TexT/Plain").header(ACCEPT)).isEqualTo(APPLICATION_JSON.value() + ", " + TEXT_PLAIN.value());
+        assertThat(new HttpObject().accept("application/json", "text/plain").hasAccept(APPLICATION_JSON.value())).isTrue();
+        assertThat(new HttpObject().accept("application/json", "text/plain").hasAccept(APPLICATION_JSON.value(), TEXT_PLAIN.value())).isTrue();
+        assertThat(new HttpObject().accept("application/json", "text/plain").hasAccept(APPLICATION_JSON.value(), TEXT_PLAIN.value(), APPLICATION_PDF.value())).isFalse();
     }
 
     @Test
-    void testGetRequestBody() throws IOException {
-        final String testBody = "{\"key\": \"value\"}";
-        final byte[] expectedStream = testBody.getBytes(Charset.defaultCharset());
-        httpObject.bodyAsString();
-        final byte[] actualBody = httpObject.body();
-        assertThat((actualBody)).isEqualTo(expectedStream);
-    }
+    void testBody() {
+        final String bodyString = "{\"key\":\"value\"}";
+        final TypeMap bodyJson = new TypeMap().putReturn("key", "value");
+        final byte[] bodyBytes = bodyString.getBytes(Charset.defaultCharset());
+        //TODO: test bodyAsXml
 
-//    private String inputStreamToString(InputStream inputStream) {
-//        try (Scanner scanner = new Scanner(inputStream, StandardCharsets.UTF_8.name()).useDelimiter("\\A")) {
-//            return scanner.hasNext() ? scanner.next() : "";
-//        }
-//    }
+        // null body
+        final HttpObject nullTest = new HttpObject();
+        assertThat(nullTest.body()).isEqualTo(new byte[0]);
+        assertThat(nullTest.bodyAsString()).isEmpty();
+        assertThat(nullTest.bodyAsJson()).isEqualTo(new TypeList().addReturn(""));
+        assertThat(nullTest.bodyAsXml()).isNotNull();
+        assertThat(nullTest.bodyAsJson().get(String.class, "key")).isNull();
+
+        // Byte[] body
+        final HttpObject byteTest = new HttpObject().body(bodyString.getBytes(Charset.defaultCharset()));
+        assertThat(byteTest.body()).isEqualTo(bodyBytes);
+        assertThat(byteTest.bodyAsString()).isEqualTo(bodyString);
+        assertThat(byteTest.bodyAsJson()).isEqualTo(bodyJson);
+        assertThat(byteTest.bodyAsXml()).isNotNull();
+        assertThat(byteTest.bodyAsJson().get(String.class, "key")).isEqualTo("value");
+
+        // String body
+        final HttpObject stringTest = new HttpObject().body(bodyString);
+        assertThat(stringTest.body()).isEqualTo(bodyBytes);
+        assertThat(stringTest.bodyAsString()).isEqualTo(bodyString);
+        assertThat(stringTest.bodyAsJson()).isEqualTo(bodyJson);
+        assertThat(stringTest.bodyAsXml()).isNotNull();
+        assertThat(stringTest.bodyAsJson().get(String.class, "key")).isEqualTo("value");
+
+        // JSON body
+        final HttpObject jsonTest = new HttpObject().body(bodyJson);
+        assertThat(jsonTest.body()).isEqualTo(bodyBytes);
+        assertThat(jsonTest.bodyAsString()).isEqualTo(bodyString);
+        assertThat(jsonTest.bodyAsJson()).isEqualTo(bodyJson);
+        assertThat(jsonTest.bodyAsXml()).isNotNull();
+        assertThat(jsonTest.bodyAsJson().get(String.class, "key")).isEqualTo("value");
+
+        // HttpExchange body
+        final HttpObject exchangeTest = new HttpObject(createMockHttpExchange("GET", "/test", new Headers(), bodyString));
+        assertThat(exchangeTest.body()).isEqualTo(bodyBytes);
+        assertThat(exchangeTest.bodyAsString()).isEqualTo(bodyString);
+        assertThat(exchangeTest.bodyAsJson()).isEqualTo(bodyJson);
+        assertThat(exchangeTest.bodyAsXml()).isNotNull();
+        assertThat(exchangeTest.bodyAsJson().get(String.class, "key")).isEqualTo("value");
+    }
 
     @Test
     void testQueryParameters() {
-        final HttpExchange exchange = createMockHttpExchange("GET", "/test?key1=value1&key2=value2", new Headers(), "");
-        final HttpObject request = new HttpObject(exchange);
-        assertThat(request.queryParameters()).hasSize(2);
-        assertThat(request.containsQueryParam("key1")).isTrue();
-        assertThat(request.containsQueryParam("key2")).isTrue();
-        assertThat(request.containsQueryParam("key3")).isFalse();
-        assertThat(request.queryParam("key1")).isEqualTo("value1");
-        assertThat(request.queryParam("key2")).isEqualTo("value2");
-        assertThat(request.queryParam("key3")).isNull();
+        final HttpObject httpObject = new HttpObject().path("/test?key1=value1&key2=value2");
+        assertThat(httpObject.queryParams()).hasSize(2);
+        assertThat(httpObject.containsQueryParam("key1")).isTrue();
+        assertThat(httpObject.containsQueryParam("key2")).isTrue();
+        assertThat(httpObject.containsQueryParam("key3")).isFalse();
+        assertThat(httpObject.queryParam("key1")).isEqualTo("value1");
+        assertThat(httpObject.queryParam("key2")).isEqualTo("value2");
+        assertThat(httpObject.queryParam("key3")).isNull();
     }
 
     @Test
-    void testExactMatch() {
-        assertThat(httpObject.exactMatch("/test")).isTrue();
-        assertThat(httpObject.exactMatch("/test/extra")).isFalse();
+    void testPathMatcher() {
+        // no ending /
+        final HttpObject httpObject1 = new HttpObject().path("/aa/bb/cc/dd?myNumber=2468");
+        assertThat(httpObject1.pathMatch("/aa/bb/cc/dd")).isTrue();
+        assertThat(httpObject1.pathMatch("/aa/bb/cc/dd/")).isTrue();
+        assertThat(httpObject1.pathMatch("/aa/{value1}/cc/{value2}/ee")).isFalse();
+        assertThat(httpObject1.pathMatch("/aa/{value1}/cc/ee")).isFalse();
+        assertThat(httpObject1.pathMatch("/aa/{value1}/cc/d")).isFalse();
+        assertThat(httpObject1.pathMatch("/aa/{value1}/cc/{value2}")).isTrue();
+        assertThat(httpObject1.pathMatch("/aa/{value1}/cc/{value2}/")).isTrue();
+        assertThat(httpObject1.pathParam("value1")).isEqualTo("bb");
+        assertThat(httpObject1.pathParams().get(String.class, "value2")).isEqualTo("dd");
+        assertThat(httpObject1.queryParams().get(Integer.class, "myNumber")).isEqualTo(2468);
+
+        // with ending /
+        final HttpObject httpObject2 = new HttpObject().path("/aa/bb/cc/dd/?myNumber=2468");
+        assertThat(httpObject2.pathMatch("/aa/bb/cc/dd")).isTrue();
+        assertThat(httpObject2.pathMatch("/aa/bb/cc/dd/")).isTrue();
+        assertThat(httpObject2.pathMatch("/aa/{value1}/cc/{value2}/ee")).isFalse();
+        assertThat(httpObject2.pathMatch("/aa/{value1}/cc/ee")).isFalse();
+        assertThat(httpObject2.pathMatch("/aa/{value1}/cc/d")).isFalse();
+        assertThat(httpObject2.pathMatch("/aa/{value1}/cc/{value2}")).isTrue();
+        assertThat(httpObject2.pathMatch("/aa/{value1}/cc/{value2}/")).isTrue();
+        assertThat(httpObject1.pathParam("value1")).isEqualTo("bb");
+        assertThat(httpObject2.pathParams().get(String.class, "value2")).isEqualTo("dd");
+        assertThat(httpObject2.queryParams().get(Integer.class, "myNumber")).isEqualTo(2468);
     }
 
     @Test
-    void testMatch() {
-        assertThat(httpObject.match("/test")).isTrue();
-        assertThat(httpObject.match("/test/extra")).isFalse();
-        assertThat(httpObject.match("/test/{param}")).isFalse();
-        assertThat(httpObject.match("/test/{param}/extra")).isFalse();
+    void testHeaders() {
+        // set headers
+        final Headers headers = new Headers();
+        headers.add("Content-Type", "Application/Json, TexT/Plain");
+        headers.put("Accept", List.of(APPLICATION_PDF.value(), APPLICATION_JSON.value()));
+        headers.add("myNumber", "123");
+        final HttpObject httpObject1 = new HttpObject().headers(headers);
+
+        // set headers map
+        final HttpObject httpObject2 = new HttpObject().headers(Map.of(
+            "Content-Type", "Application/Json, TexT/Plain",
+            "Accept", List.of(APPLICATION_PDF, APPLICATION_JSON.value()),
+            "myNumber", "123"
+        ));
+
+        // add headers
+        final HttpObject httpObject3 = new HttpObject()
+            .header("Content-Type", "Application/Json, TexT/Plain")
+            .header("Accept", List.of(APPLICATION_PDF, APPLICATION_JSON.value()))
+            .header("myNumber", "123")
+            .header(null, "aa")
+            .header("bb", null);
+
+        for (final HttpObject httpObject : List.of(httpObject1, httpObject2, httpObject3)) {
+            assertThat(httpObject.headers()).hasSize(3);
+            assertThat(httpObject.containsHeader("mynumber")).isTrue();
+            assertThat(httpObject.containsHeader("myNumber")).isTrue();
+            assertThat(httpObject.header("myNumber")).isEqualTo("123");
+            assertThat(httpObject.header("mynumber")).isEqualTo("123");
+            assertThat(httpObject.headers().get(Integer.class, "mynumber")).isEqualTo(123);
+            assertThat(httpObject.contentTypes()).containsExactly(APPLICATION_JSON, TEXT_PLAIN);
+            assertThat(httpObject.accepts()).containsExactly(APPLICATION_PDF, APPLICATION_JSON);
+        }
     }
 
     @Test
-    void testHeaderMethods() {
-        assertThat(httpObject.header("content-type")).isEqualTo("application/json");
-        assertThat(httpObject.getHeaders()).containsKey("content-type");
-    }
+    void testCaller() {
+        final HttpObject httpObject1 = new HttpObject().header(HttpHeaders.HOST, "example.com:1337");
+        assertThat(httpObject1.host()).isEqualTo("example.com");
+        assertThat(httpObject1.address()).isNull();
+        assertThat(httpObject1.port()).isEqualTo(1337);
 
-    @Test
-    void testPathParams() {
-        final HttpExchange exchange = createMockHttpExchange("GET", "/test/param1/param2", new Headers(), "");
-        final HttpObject request = new HttpObject(exchange);
-
-        request.match("/test/{param1}/{param2}");
-        assertThat(request.pathParams()).hasSize(2);
-        assertThat(request.pathParam("param1")).isEqualTo("param1");
-        assertThat(request.pathParam("param2")).isEqualTo("param2");
-
-    }
-
-    @Test
-    void testcontainsHeader() {
-        assertThat(httpObject.containsHeader("content-type")).isTrue();
-        assertThat(httpObject.containsHeader("accept")).isTrue();
-    }
-
-    @Test
-    void testPort() {
-        assertThat(httpObject.port()).isEqualTo(1337);
-    }
-
-    @Test
-    void testHost() {
-        assertThat(httpObject.host()).isEqualTo("example.com");
+        // with exchange
+        final HttpObject httpObject2 = new HttpObject(createMockHttpExchange("GET", "/test", new Headers(), ""));
+        assertThat(httpObject2.host()).isEqualTo("example.com");
+        assertThat(httpObject2.address()).isNotNull();
+        assertThat(httpObject2.port()).isEqualTo(1337);
     }
 
     @Test
     void testProtocol() {
-        assertThat(httpObject.protocol()).isEqualTo(PROTOCOL);
+        final HttpObject httpObject1 = new HttpObject().header(HttpHeaders.HOST, "example.com:1337");
+        assertThat(httpObject1.protocol()).isNull();
+
+        // with exchange
+        final HttpObject httpObject2 = new HttpObject(createMockHttpExchange("GET", "/test", new Headers(), ""));
+        assertThat(httpObject2.protocol()).isEqualTo("HTTP/1.1");
     }
 
     @Test
-    void testUserAgent() {
-        final Headers headers = new Headers();
-        headers.add("User-Agent", AGENT);
-        final HttpExchange exchange = createMockHttpExchange("GET", "/test", headers, "");
-        final HttpObject request = new HttpObject(exchange);
-        assertThat(request.userAgent()).isEqualTo(AGENT);
+    void testHeaderUserAgent() {
+        assertThat(new HttpObject().header(USER_AGENT, "PostmanRuntime/7.36.3").header(USER_AGENT)).isEqualTo("PostmanRuntime/7.36.3");
+        assertThat(new HttpObject().header(USER_AGENT, "PostmanRuntime/7.36.3").userAgent()).isEqualTo("PostmanRuntime/7.36.3");
     }
 
     @Test
     void testAuthToken() {
-        final Headers headers = new Headers();
-        headers.add("Authorization", TOKEN);
-        final HttpExchange exchange = createMockHttpExchange("GET", "/test", headers, "");
-        final HttpObject request = new HttpObject(exchange);
-        assertThat(request.authToken()).isEqualTo("123");
+        assertThat(new HttpObject().header(AUTHORIZATION, "Bearer 123").authToken()).containsExactly("123");
+        assertThat(new HttpObject().header(AUTHORIZATION, "Basic QWxhZGRpbjpPcGVuU2VzYW1l").authToken()).containsExactly("Aladdin", "OpenSesame");
     }
 
     @Test
-    void testAuthBasic() {
-        final Headers headers = new Headers();
-        // todo : add basic token auth
+    void testHeaderLanguage() {
+        final HttpObject httpObject = new HttpObject().header(ACCEPT_LANGUAGE, "en-US,en;q=0.9,de;q=0.8");
+        assertThat(httpObject.acceptLanguage()).isEqualTo(Locale.of("en", "us"));
+        assertThat(httpObject.acceptLanguages()).containsExactly(Locale.of("en", "us"), Locale.ENGLISH, Locale.GERMAN);
     }
 
     @Test
-    void testBasicAuth() {
-        final Headers headers = new Headers();
-        headers.add(HttpHeaders.AUTHORIZATION, "Basic QWxhZGRpbjpPcGVuU2VzYW1l");
-        final HttpExchange exchange = createMockHttpExchange("GET", "/test", headers, "");
-        final HttpObject request = new HttpObject(exchange);
-        final String[] credentials1 = request.basicAuth();
-        assertThat(credentials1).containsExactly("Aladdin", "OpenSesame");
-    }
-
-    @Test
-    void testPreferredLanguages() {
-        final Headers headers = new Headers();
-        headers.add("Accept-Language", "en-US,en;q=0.9,de;q=0.8");
-        final HttpExchange exchange = createMockHttpExchange("GET", "/test", headers, "");
-        final HttpObject request = new HttpObject(exchange);
-        assertThat(request.acceptLanguages()).containsExactly(Locale.of("en", "us"), Locale.ENGLISH, Locale.GERMAN);
-    }
-
-    @Test
-    // todo : getList is not returning casted listed
-    void testContentType() {
-        final Headers headers = new Headers();
-        headers.add("Content-Type", "application/json");
-        final HttpExchange exchange = createMockHttpExchange("GET", "/test", headers, "");
-        final HttpObject request = new HttpObject(exchange);
-        assertThat(request.contentTypes()).containsExactly(ContentType.APPLICATION_JSON);
-        assertThat(httpObject.contentType()).isEqualTo(ContentType.APPLICATION_JSON);
-    }
-
-    @Test
-    void testHasAccept_StringArray() {
-        final boolean result = httpObject.hasAccept("application/json", "text/html");
-        assertThat(result).isTrue();
-    }
-
-    @Test
-    void testHasAccept_ContentType() {
-
-        final boolean result = httpObject.hasAccept(ContentType.APPLICATION_JSON);
-        assertThat(result).isTrue();
-    }
-
-    @Test
-    void testAcceptEncoding() {
-
-        final String result = httpObject.acceptEncoding();
-        assertThat(result).isEqualTo("gzip");
-    }
-
-    @Test
-    void testHasAcceptEncoding_StringArray() {
-        final boolean result = httpObject.hasAcceptEncoding("gzip", "deflate");
-
-        assertThat(result).isTrue();
-    }
-
-    @Test
-    void testAccepts() {
-
-        final List<ContentType> result = httpObject.accepts();
-        assertThat(result).containsExactly(ContentType.APPLICATION_JSON, ContentType.TEXT_HTML);
-    }
-
-    @Test
-    void testAccept() {
-
-        final ContentType result = httpObject.accept();
-        assertThat(result).isEqualTo(ContentType.APPLICATION_JSON);
-    }
-
-    @Test
-    void testAcceptLanguage() {
-
-        final List<Locale> result = httpObject.acceptLanguage();
-        assertThat(result).containsExactly(Locale.US);
-    }
-
-    @Test
-    void testBodyAsXml() {
-        final String xmlBody = "<name>John</name>";
-        final HttpExchange exchange = createMockHttpExchange("GET", "/test", new Headers(), xmlBody);
-        httpObject = new HttpObject(exchange);
-
-        final TypeContainer<?> result = httpObject.bodyAsXml();
-
-        final TypeContainer<?> expected = XmlDecoder.xmlTypeOf(xmlBody);
-        assertThat(result).isEqualTo(expected);
+    void testHeaderAcceptEncoding() {
+        final HttpObject httpObject = new HttpObject().header(ACCEPT_ENCODING, List.of("gzip", "deflate"));
+        assertThat(httpObject.acceptEncoding()).isEqualTo("gzip");
+        assertThat(httpObject.acceptEncodings()).containsExactly("gzip", "deflate");
+        assertThat(httpObject.hasAcceptEncoding("gzip", "deflate")).isTrue();
+        assertThat(httpObject.hasAcceptEncoding("gzip", "deflate", "unknown")).isFalse();
     }
 
     @Test
     void testHttpObjectMethods() {
         // Create a sample HTTP response
-        final HttpObject httpObject = new HttpObject();
-        httpObject.statusCode(200)
-            .body("Sample body".getBytes())
-            .headers(createSampleHeaders());
-
-        assertEquals(200, httpObject.statusCode());
-        assertArrayEquals("Sample body".getBytes(), httpObject.body());
-
-//        assertEquals(createSampleHeaders(), httpObject.headers());
-
-        httpObject.statusCode(404);
-        assertEquals(404, httpObject.statusCode());
-
-        final HttpObject httpObjectCopy = new HttpObject();
-        httpObjectCopy.statusCode(404)
-            .body("Sample body".getBytes())
-            .headers(createSampleHeaders());
-        assertEquals(httpObjectCopy, httpObject);
+//        final HttpObject httpObject = new HttpObject();
+//        httpObject.statusCode(200)
+//            .body("Sample body".getBytes())
+//            .headers(createSampleHeaders());
+//
+//        assertEquals(200, httpObject.statusCode());
+//        assertArrayEquals("Sample body".getBytes(), httpObject.body());
+//
+////        assertEquals(createSampleHeaders(), httpObject.headers());
+//
+//        httpObject.statusCode(404);
+//        assertEquals(404, httpObject.statusCode());
+//
+//        final HttpObject httpObjectCopy = new HttpObject();
+//        httpObjectCopy.statusCode(404)
+//            .body("Sample body".getBytes())
+//            .headers(createSampleHeaders());
+//        assertEquals(httpObjectCopy, httpObject);
 
 //        assertEquals(httpObjectCopy.hashCode(), httpObject.hashCode());
-        final String expectedToString = "HttpObject[statusCode=404, body=[83, 97, 109, 112, 108, 101, 32, 98, 111, 100, 121], headers={Header1=Value1, Header2=Value2, NewHeader=Value}]";
+//        final String expectedToString = "HttpObject[statusCode=404, body=[83, 97, 109, 112, 108, 101, 32, 98, 111, 100, 121], headers={Header1=Value1, Header2=Value2, NewHeader=Value}]";
 //        assertEquals(expectedToString, httpObject.toString());
     }
 
     // Utility method to create sample headers
     private Map<String, String> createSampleHeaders() {
-        return  Map.of("Content-Type", "application/json");
+        return Map.of("Content-Type", "application/json");
     }
 
     @Test
@@ -425,7 +444,7 @@ class HttpRequestTest {
 
             @Override
             public InputStream getRequestBody() {
-                return new ByteArrayInputStream(testBody.getBytes(StandardCharsets.UTF_8));
+                return new ByteArrayInputStream(testBody.getBytes(Charset.defaultCharset()));
             }
 
             @Override
@@ -434,13 +453,13 @@ class HttpRequestTest {
             }
 
             @Override
-            public void sendResponseHeaders(final int rCode, final long responseLength) throws IOException {
+            public void sendResponseHeaders(final int rCode, final long responseLength) {
 
             }
 
             @Override
             public InetSocketAddress getRemoteAddress() {
-                return null;
+                return new InetSocketAddress("example.com", 1337);
             }
 
             @Override
@@ -450,12 +469,12 @@ class HttpRequestTest {
 
             @Override
             public InetSocketAddress getLocalAddress() {
-                return new InetSocketAddress(HOST, PORT);
+                return null;
             }
 
             @Override
             public String getProtocol() {
-                return PROTOCOL;
+                return "HTTP/1.1";
             }
 
             @Override

--- a/src/test/java/berlin/yuna/nano/model/HttpRequestTest.java
+++ b/src/test/java/berlin/yuna/nano/model/HttpRequestTest.java
@@ -166,8 +166,6 @@ class HttpRequestTest {
 
     @Test
     void testHeaderContentType() {
-        //TODO: test use case "Content-Type: application/json; charset=utf-8"
-
         // ENUM
         assertThat(new HttpObject().contentType(APPLICATION_JSON).contentType()).isEqualTo(APPLICATION_JSON);
         assertThat(new HttpObject().contentType(APPLICATION_JSON).contentTypes()).containsExactly(APPLICATION_JSON);

--- a/src/test/java/berlin/yuna/nano/model/HttpRequestTest.java
+++ b/src/test/java/berlin/yuna/nano/model/HttpRequestTest.java
@@ -17,6 +17,7 @@ import java.io.OutputStream;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -24,8 +25,8 @@ import java.util.Map;
 
 import static berlin.yuna.nano.services.http.model.ContentType.*;
 import static berlin.yuna.nano.services.http.model.HttpHeaders.*;
+import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class HttpRequestTest {
 
@@ -184,6 +185,19 @@ class HttpRequestTest {
         assertThat(httpObject.hasAcceptGif()).isFalse();
         assertThat(httpObject.hasAcceptMpeg()).isFalse();
         assertThat(httpObject.hasAcceptMp4()).isFalse();
+    }
+
+    @Test
+    void testContentTypeEncoding() {
+        // ENUM
+        assertThat(new HttpObject().contentType(APPLICATION_JSON).encoding()).isEqualTo(Charset.defaultCharset());
+        assertThat(new HttpObject().contentType(US_ASCII, APPLICATION_PDF).header(CONTENT_TYPE)).isEqualTo(APPLICATION_PDF.value() + "; charset=" + US_ASCII);
+        assertThat(new HttpObject().contentType(US_ASCII, APPLICATION_PDF).encoding()).isEqualTo(US_ASCII);
+
+        // STRING
+        assertThat(new HttpObject().contentType(APPLICATION_JSON.value()).encoding()).isEqualTo(Charset.defaultCharset());
+        assertThat(new HttpObject().contentType(US_ASCII, APPLICATION_PDF.value()).header(CONTENT_TYPE)).isEqualTo(APPLICATION_PDF.value() + "; charset=" + US_ASCII);
+        assertThat(new HttpObject().contentType(US_ASCII, APPLICATION_PDF.value()).encoding()).isEqualTo(US_ASCII);
     }
 
     @Test

--- a/src/test/java/berlin/yuna/nano/model/HttpRequestTest.java
+++ b/src/test/java/berlin/yuna/nano/model/HttpRequestTest.java
@@ -119,6 +119,10 @@ class HttpRequestTest {
         assertThat(new HttpObject().contentType("application/json", "TexT/Plain").hasContentType(APPLICATION_JSON.value())).isTrue();
         assertThat(new HttpObject().contentType("application/json", "TexT/Plain").hasContentType(APPLICATION_JSON.value(), TEXT_PLAIN.value())).isTrue();
         assertThat(new HttpObject().contentType("application/json", "TexT/Plain").hasContentType(APPLICATION_JSON.value(), TEXT_PLAIN.value(), APPLICATION_PDF.value())).isFalse();
+
+        // General
+        assertThat(new HttpObject().contentTypes()).isEmpty();
+        assertThat(new HttpObject().contentType()).isNull();
     }
 
     @Test
@@ -174,6 +178,10 @@ class HttpRequestTest {
         assertThat(new HttpObject().accept("application/json", "text/plain").hasAccept(APPLICATION_JSON.value())).isTrue();
         assertThat(new HttpObject().accept("application/json", "text/plain").hasAccept(APPLICATION_JSON.value(), TEXT_PLAIN.value())).isTrue();
         assertThat(new HttpObject().accept("application/json", "text/plain").hasAccept(APPLICATION_JSON.value(), TEXT_PLAIN.value(), APPLICATION_PDF.value())).isFalse();
+
+        // General
+        assertThat(new HttpObject().accepts()).isEmpty();
+        assertThat(new HttpObject().accept()).isNull();
     }
 
     @Test
@@ -222,6 +230,11 @@ class HttpRequestTest {
         assertThat(exchangeTest.bodyAsJson()).isEqualTo(bodyJson);
         assertThat(exchangeTest.bodyAsXml()).isNotNull();
         assertThat(exchangeTest.bodyAsJson().get(String.class, "key")).isEqualTo("value");
+
+        // General
+        assertThat(new HttpObject().bodyAsJson()).isEqualTo(new TypeList().addReturn(""));
+        assertThat(new HttpObject().bodyAsXml()).isEqualTo(new TypeList());
+        assertThat(new HttpObject().bodyAsString()).isEmpty();
     }
 
     @Test
@@ -234,6 +247,10 @@ class HttpRequestTest {
         assertThat(httpObject.queryParam("key1")).isEqualTo("value1");
         assertThat(httpObject.queryParam("key2")).isEqualTo("value2");
         assertThat(httpObject.queryParam("key3")).isNull();
+
+        // General
+        assertThat(new HttpObject(createMockHttpExchange("GET", "/test?key1=value1&key2=value2", new Headers(), "{\"key\": \"value\"}")).queryParams()).hasSize(2);
+        assertThat(new HttpObject().queryParams()).isEmpty();
     }
 
     @Test
@@ -263,6 +280,10 @@ class HttpRequestTest {
         assertThat(httpObject1.pathParam("value1")).isEqualTo("bb");
         assertThat(httpObject2.pathParams().get(String.class, "value2")).isEqualTo("dd");
         assertThat(httpObject2.queryParams().get(Integer.class, "myNumber")).isEqualTo(2468);
+
+        // General
+        assertThat(new HttpObject().path(null).pathMatch("/aa/bb/cc/dd")).isFalse();
+        assertThat(new HttpObject().path(null).pathMatch(null)).isFalse();
     }
 
     @Test
@@ -293,6 +314,8 @@ class HttpRequestTest {
             assertThat(httpObject.headers()).hasSize(3);
             assertThat(httpObject.containsHeader("mynumber")).isTrue();
             assertThat(httpObject.containsHeader("myNumber")).isTrue();
+            assertThat(httpObject.containsHeader("invalid")).isFalse();
+            assertThat(httpObject.containsHeader(null)).isFalse();
             assertThat(httpObject.header("myNumber")).isEqualTo("123");
             assertThat(httpObject.header("mynumber")).isEqualTo("123");
             assertThat(httpObject.headers().get(Integer.class, "mynumber")).isEqualTo(123);
@@ -342,6 +365,10 @@ class HttpRequestTest {
         final HttpObject httpObject = new HttpObject().header(ACCEPT_LANGUAGE, "en-US,en;q=0.9,de;q=0.8");
         assertThat(httpObject.acceptLanguage()).isEqualTo(Locale.of("en", "us"));
         assertThat(httpObject.acceptLanguages()).containsExactly(Locale.of("en", "us"), Locale.ENGLISH, Locale.GERMAN);
+
+        // General
+        assertThat(new HttpObject().acceptLanguages()).isEmpty();
+        assertThat(new HttpObject().acceptLanguage()).isNull();
     }
 
     @Test
@@ -351,6 +378,10 @@ class HttpRequestTest {
         assertThat(httpObject.acceptEncodings()).containsExactly("gzip", "deflate");
         assertThat(httpObject.hasAcceptEncoding("gzip", "deflate")).isTrue();
         assertThat(httpObject.hasAcceptEncoding("gzip", "deflate", "unknown")).isFalse();
+
+        // General
+        assertThat(new HttpObject().acceptEncodings()).isEmpty();
+        assertThat(new HttpObject().acceptEncoding()).isNull();
     }
 
     @Test


### PR DESCRIPTION
### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation
> * Tests should be independent from each other
> * Test fluent chaining getters and setters

## Changes
> * There are many hanges and logic fixes
> * renamed `getHeaders()` > `headers()`
> * added header methods to add or set headers
> * `HttpRequest` works now independent of `HttpExchange`
> * removed `exactMatch` as `pathMatch` is alrady taking care of everything
> * added multiple null safety checks
> * `host`, `port`, `address` is now returning the caller information and reads the header information as well
> * rearanged methods `public` > `protected` > `private` > `static` ....
> * fixed body cache at get `body()` method
> * merged `authToken` and `basicAuth`
> * cleanded up tests
> * [...]

## Success Check
> Automated tests
