### PR TITLE
feat(config): added config property files reader

### DIFF
--- a/src/main/java/berlin/yuna/nano/core/NanoServices.java
+++ b/src/main/java/berlin/yuna/nano/core/NanoServices.java
@@ -35,8 +35,8 @@ public abstract class NanoServices<T extends NanoServices<T>> extends NanoThread
     protected NanoServices(final Map<Object, Object> config, final String... args) {
         super(config, args);
         this.services = new CopyOnWriteArrayList<>();
-        addEventListener(EVENT_APP_SERVICE_REGISTER, event -> event.payloadOpt(Service.class).map(this::registerService).ifPresent(nano -> event.acknowledge()));
-        addEventListener(EVENT_APP_SERVICE_UNREGISTER, event -> event.payloadOpt(Service.class).map(service -> unregisterService(event.context(), service)).ifPresent(nano -> event.acknowledge()));
+        subscribeEvent(EVENT_APP_SERVICE_REGISTER, event -> event.payloadOpt(Service.class).map(this::registerService).ifPresent(nano -> event.acknowledge()));
+        subscribeEvent(EVENT_APP_SERVICE_UNREGISTER, event -> event.payloadOpt(Service.class).map(service -> unregisterService(event.context(), service)).ifPresent(nano -> event.acknowledge()));
     }
 
     /**

--- a/src/main/java/berlin/yuna/nano/core/NanoThreads.java
+++ b/src/main/java/berlin/yuna/nano/core/NanoThreads.java
@@ -37,8 +37,8 @@ public abstract class NanoThreads<T extends NanoThreads<T>> extends NanoBase<T> 
     protected NanoThreads(final Map<Object, Object> config, final String... args) {
         super(config, args);
         this.schedulers = ConcurrentHashMap.newKeySet();
-        addEventListener(EVENT_APP_SCHEDULER_REGISTER, event -> event.payloadOpt(ScheduledExecutorService.class).map(schedulers::add).ifPresent(nano -> event.acknowledge()));
-        addEventListener(EVENT_APP_SCHEDULER_UNREGISTER, event -> event.payloadOpt(ScheduledExecutorService.class).map(scheduler -> {
+        subscribeEvent(EVENT_APP_SCHEDULER_REGISTER, event -> event.payloadOpt(ScheduledExecutorService.class).map(schedulers::add).ifPresent(nano -> event.acknowledge()));
+        subscribeEvent(EVENT_APP_SCHEDULER_UNREGISTER, event -> event.payloadOpt(ScheduledExecutorService.class).map(scheduler -> {
             scheduler.shutdown();
             schedulers.remove(scheduler);
             return this;

--- a/src/main/java/berlin/yuna/nano/core/model/Config.java
+++ b/src/main/java/berlin/yuna/nano/core/model/Config.java
@@ -16,6 +16,7 @@ public enum Config {
     APP_HELP("help", "Lists available config keys (see " + Config.class.getSimpleName() + ")"),
     APP_PARAMS("app_params_print", "Pints all config values"),
     CONFIG_APP_NAME("app_name", "Changes the name in the log output"), // TODO: implement this
+    CONFIG_PROFILES("app_profiles", "Active config profiles for the application"),
     CONFIG_LOG_LEVEL("app_log_level", "Log level for the application (see " + LogLevel.class.getSimpleName() + ")"),
     CONFIG_LOG_FORMATTER("app_log_formatter", "Log formatter (see " + LogFormatRegister.class.getSimpleName() + ")"),
     CONFIG_LOG_QUEUE_SIZE("app_log_queue_size", "Log queue size. A full queue means that log messages will start to wait to be executed (see " + LogQueue.class.getSimpleName() + ")"),

--- a/src/main/java/berlin/yuna/nano/core/model/Context.java
+++ b/src/main/java/berlin/yuna/nano/core/model/Context.java
@@ -177,7 +177,7 @@ public class Context extends ConcurrentTypeMap {
      * @return Self for chaining
      */
     public Context subscribeEvent(final int eventType, final Consumer<Event> listener) {
-        nano.addEventListener(eventType, listener);
+        nano.subscribeEvent(eventType, listener);
         return this;
     }
 
@@ -189,7 +189,7 @@ public class Context extends ConcurrentTypeMap {
      * @return Self for chaining
      */
     public Context unsubscribeEvent(final int eventType, final Consumer<Event> listener) {
-        nano.removeEventListener(eventType, listener);
+        nano.unsubscribeEvent(eventType, listener);
         return this;
     }
 

--- a/src/main/java/berlin/yuna/nano/helper/NanoUtils.java
+++ b/src/main/java/berlin/yuna/nano/helper/NanoUtils.java
@@ -157,10 +157,19 @@ public class NanoUtils {
         if (!"".equals(profile))
             scannedProfiles.add(profile);
         result.put("_scanned_profiles", scannedProfiles);
-        for (final String directory : new String[]{"", ".", "config/", ".config/", "resources/", ".resources/", "resources/config/", ".resources/config/"}) {
+
+        for (final String directory : new String[]{
+            "",
+            ".",
+            "config/",
+            ".config/",
+            "resources/",
+            ".resources/",
+            "resources/config/",
+            ".resources/config/"
+        }) {
             readConfigFile(result, directory + "application" + (profile.isEmpty() ? profile : "-" + profile) + ".properties");
         }
-
         return readProfiles(result);
     }
 

--- a/src/main/java/berlin/yuna/nano/services/http/HttpService.java
+++ b/src/main/java/berlin/yuna/nano/services/http/HttpService.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 
+import static berlin.yuna.nano.core.model.Config.CONFIG_SERVICE_HTTP_PORT;
 import static berlin.yuna.nano.helper.event.model.EventType.*;
 
 public class HttpService extends Service {
@@ -42,8 +43,9 @@ public class HttpService extends Service {
     public synchronized void start(final Supplier<Context> contextSub) {
         isReady.set(false, true, state -> {
             final Context context = contextSub.get().newContext(HttpService.class, null);
+            final int port = context.getOpt(Integer.class, CONFIG_SERVICE_HTTP_PORT.id()).filter(p -> p > 0).orElseGet(() -> nextFreePort(8080));
+            context.put(CONFIG_SERVICE_HTTP_PORT, port);
             handleHttps(context);
-            final int port = context.getOpt(Integer.class, "app_service_http_port").filter(p -> p > 0).orElseGet(() -> nextFreePort(8080));
             try {
                 server = HttpServer.create(new InetSocketAddress(port), 0);
                 server.setExecutor(context.nano().threadPool());

--- a/src/main/java/berlin/yuna/nano/services/http/model/HttpObject.java
+++ b/src/main/java/berlin/yuna/nano/services/http/model/HttpObject.java
@@ -17,6 +17,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static berlin.yuna.nano.helper.NanoUtils.split;
 import static berlin.yuna.nano.services.http.model.HttpHeaders.ACCEPT;
 import static berlin.yuna.nano.services.http.model.HttpHeaders.CONTENT_TYPE;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -457,7 +458,7 @@ public class HttpObject {
      * Supports both 'Bearer' and 'Basic' authentication schemes.
      *
      * @return an array of strings, where the first element is the token or credentials,
-     *         or an empty array if no {@link HttpHeaders#AUTHORIZATION} header is present or the token cannot be parsed.
+     * or an empty array if no {@link HttpHeaders#AUTHORIZATION} header is present or the token cannot be parsed.
      */
     public String[] authToken() {
         return ofNullable(header(HttpHeaders.AUTHORIZATION))
@@ -927,20 +928,4 @@ public class HttpObject {
     public static String removeLast(final String input, final String removable) {
         return input.length() > removable.length() && input.endsWith(removable) ? input.substring(0, input.length() - removable.length()) : input;
     }
-
-    public static String[] split(final String input, final String delimiter) {
-        if (!input.contains(delimiter)) {
-            return new String[]{input};
-        }
-        final List<String> result = new ArrayList<>();
-        int start = 0;
-        int index;
-        while ((index = input.indexOf(delimiter, start)) != -1) {
-            result.add(input.substring(start, index));
-            start = index + delimiter.length();
-        }
-        result.add(input.substring(start));
-        return result.toArray(new String[0]);
-    }
-
 }

--- a/src/test/java/berlin/yuna/nano/examples/Yuna.java
+++ b/src/test/java/berlin/yuna/nano/examples/Yuna.java
@@ -15,7 +15,7 @@ import static berlin.yuna.nano.core.model.Config.CONFIG_LOG_FORMATTER;
 import static berlin.yuna.nano.core.model.Config.CONFIG_LOG_LEVEL;
 import static berlin.yuna.nano.helper.event.model.EventType.EVENT_APP_SHUTDOWN;
 
-public class App {
+public class Yuna {
 
     public static void main(final String[] args) {
         //TODO: Dynamic Queues to Services
@@ -32,7 +32,7 @@ public class App {
         final Service serviceC = new ServiceC();
         final Service serviceD = new ServiceD();
 
-        final Context ctx = application.newContext(App.class);
+        final Context ctx = application.newContext(Yuna.class);
         ctx.run(serviceA)
             .run(serviceA)
             .runAwait(serviceB, serviceC)
@@ -56,7 +56,7 @@ public class App {
         ;
 
         application.run(() -> {
-            final Context context = application.newContext(App.class);
+            final Context context = application.newContext(Yuna.class);
             context.sendEvent(EVENT_APP_SHUTDOWN, null);
             context.sendEvent(99, null);
         }, 5, 5, TimeUnit.SECONDS, () -> false);

--- a/src/test/resources/application-local.properties
+++ b/src/test/resources/application-local.properties
@@ -1,0 +1,2 @@
+app.profiles=default, local, dev, prod
+resource.key2=CC

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,8 @@
+resource.key1=AA
+resource.key2=BB
+app.profile=local
+test.placeholder.fallback=${invalid_key:fallback should be used 1}
+test.placeholder.fallback.empty=${invalid_key:}
+test.placeholder.value=${placeholder_value:fallback should not be used}
+test.placeholder.key_empty=${:fallback should be used 2}
+placeholder_value=used placeholder value


### PR DESCRIPTION
Closes #8 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Motivation
> Nano should be able to read different configs dependent on the configured profile

## Changes
> `NanoBase` reads config files (aka `application.properties`)
> Configs can now have placeholders
> Config profiles are now configurable e.g. `app.profile=local` (other spellings are accepted as well like `spring_profiles_active`)
> config file locations `config`, `resources`, `recources/config`

## Success Check
> Test covered
